### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -28,6 +28,8 @@ jobs:
 
   sast-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       GO111MODULE: on
 


### PR DESCRIPTION
Potential fix for [https://github.com/Technochip/Test-workflows/security/code-scanning/28](https://github.com/Technochip/Test-workflows/security/code-scanning/28)

To fix the problem, explicitly set the `permissions` for the `sast-check` job so that the `GITHUB_TOKEN` is limited to only what the job requires. Since this job only needs to read the repository contents to run gosec, the minimal and appropriate permission is `contents: read`.

Concretely, in `.github/workflows/gosec.yml`, under `jobs:`, locate the `sast-check:` job (starting at line 29). Add a `permissions:` block at the same indentation level as `runs-on:` and `env:` for that job, setting `contents: read`. This mirrors how `permissions` is already defined for the `test` job but with a simpler, strictly read-only scope. No new imports, methods, or external libraries are needed; this is purely a YAML configuration change to the GitHub Actions workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
